### PR TITLE
* wgrep-helm.el: Add hook for helm-moccur-mode.

### DIFF
--- a/wgrep-helm.el
+++ b/wgrep-helm.el
@@ -83,6 +83,9 @@
 ;;;###autoload(add-hook 'helm-grep-mode-hook 'wgrep-helm-setup)
 (add-hook 'helm-grep-mode-hook 'wgrep-helm-setup)
 
+;;;###autoload(add-hook 'helm-moccur-mode-hook 'wgrep-helm-setup)
+(add-hook 'helm-moccur-mode-hook 'wgrep-helm-setup)
+
 ;; For `unload-feature'
 (defun wgrep-helm-unload-function ()
   (remove-hook 'helm-grep-mode-hook 'wgrep-helm-setup))


### PR DESCRIPTION
helm-moccur-mode is a new mode to save helm-(m)occur buffers, it is working with wgrep, just need the hook.
