### PR TITLE
Make last group in wgrep-ag editable

### DIFF
--- a/wgrep-ag.el
+++ b/wgrep-ag.el
@@ -64,27 +64,28 @@ when you manage to call ag with --nogroup.")
   (save-excursion
     (goto-char (point-min))
     ;; Look for the first useful result line.
-    (let ((result-line-regexp (concat wgrep-ag-grouped-result-file-regexp
-                                      "\\|"
-                                      wgrep-ag-ungrouped-result-regexp)))
-      (if (not (re-search-forward result-line-regexp nil t))
-          ;; No results in this buffer, let's mark the whole thing as
-          ;; header.
-          (add-text-properties (point-min) (point-max)
-                               '(read-only t wgrep-header t))
-        (add-text-properties (point-min) (line-beginning-position)
-                             '(read-only t wgrep-header t))
-        (goto-char (point-max))
-        (re-search-backward result-line-regexp nil t)
-        ;; Point is now at the beginning of the result nearest the end
-        ;; of the buffer, AKA the last result.  Move to the start of
-        ;; the line after the last result, and mark everything from
-        ;; that line forward as wgrep-footer.  If we can't move to the
-        ;; line after the last line then there apparently is no
-        ;; footer.
-        (when (zerop (forward-line 1))
-          (add-text-properties (point) (point-max)
-                               '(read-only t wgrep-footer t)))))))
+    (if (re-search-forward (concat wgrep-ag-grouped-result-file-regexp
+				   "\\|"
+				   wgrep-ag-ungrouped-result-regexp))
+	(add-text-properties (point-min) (line-beginning-position)
+			     '(read-only t wgrep-header t))
+      ;; No results in this buffer, let's mark the whole thing as
+      ;; header.
+      (add-text-properties (point-min) (point-max)
+			   '(read-only t wgrep-header t)))
+
+    ;; OK, header dealt with. Now let's try find the footer.
+    (goto-char (point-max))
+    (re-search-backward "^\\(?:-[^:]+?:[[:digit:]]+:[[:digit:]]+:\\)" nil t)
+    ;; Point is now at the beginning of the result nearest the end
+    ;; of the buffer, AKA the last result.  Move to the start of
+    ;; the line after the last result, and mark everything from
+    ;; that line forward as wgrep-footer.  If we can't move to the
+    ;; line after the last line then there apparently is no
+    ;; footer.
+    (when (zerop (forward-line 1))
+      (add-text-properties (point) (point-max)
+			   '(read-only t wgrep-footer t)))))
 
 (defun wgrep-ag-parse-command-results ()
   ;; Note that this function is called with the buffer narrowed to


### PR DESCRIPTION
This fixes issue #60.

The previous would always include the last grouped result as part of the footer. This version matches the last line in the group, rather than the _start_ of the group to fix that error.