### PR TITLE
wgrep-helm.el: Add missing Package-Requires for helm

### DIFF
--- a/wgrep-helm.el
+++ b/wgrep-helm.el
@@ -4,7 +4,7 @@
 
 ;; Author: Masahiro Hayashi <mhayashi1120@gmail.com>
 ;; Keywords: grep edit extensions
-;; Package-Requires: ((wgrep "2.1.1"))
+;; Package-Requires: ((wgrep "2.1.1") (helm "1.4.0"))
 ;; URL: http://github.com/mhayashi1120/Emacs-wgrep/raw/master/wgrep-helm.el
 ;; Emacs: GNU Emacs 25 or later
 ;; Version: 2.3.2


### PR DESCRIPTION
This package requires helm, because it uses helm-grep-split-line from
helm-grep.el.  See wgrep-helm.el:L47.

wgrep-helm.el first appeared in 1.4.0, so I've set that as the
required version.