### PR TITLE
Selftests: add missing deps

### DIFF
--- a/wgrep-subtest.el
+++ b/wgrep-subtest.el
@@ -1,5 +1,6 @@
 (require 'ert)
 (require 'wgrep-test)
+(require 'ag)
 
 (defun wgrep-test--ag (string file)
   (let ((buf (ag/search string default-directory :file-regex (regexp-quote file) :regexp t)))

--- a/wgrep-test.el
+++ b/wgrep-test.el
@@ -1,6 +1,7 @@
 (require 'ert)
 (require 'dash)
 (require 's)
+(require 'wgrep)
 
 (defun wgrep-test--wait (buf)
   (let ((proc (get-buffer-process buf)))

--- a/wgrep-test.el
+++ b/wgrep-test.el
@@ -1,4 +1,6 @@
 (require 'ert)
+(require 'dash)
+(require 's)
 
 (defun wgrep-test--wait (buf)
   (let ((proc (get-buffer-process buf)))


### PR DESCRIPTION
Hi @mhayashi1120,

It looks like I forgot to forward these fixes last month.  As for the "why" of the fix: unit tests should declare their deps.  This is necessary to support a couple of different cases, including 1) a user who wants to check if their packages function properly with a git snapshot of Emacs, running the tests via `ert-run-tests-interactively`  2) `ert-run-tests-batch-and-exit` needs to be functional in the Debian source package.

Thanks,
Nicholas