### PR TITLE
use headings that are compatible with outline-minor-mode

### DIFF
--- a/wgrep.el
+++ b/wgrep.el
@@ -123,9 +123,9 @@
 ;;; Variable / Constant
 ;;;
 
-;;
-;; Customize
-;;
+;;;;
+;;;; Customize
+;;;;
 
 (defcustom wgrep-change-readonly-file nil
   "Non-nil means to enable change read-only files."
@@ -153,9 +153,9 @@ Key to enable `wgrep-mode'."
 
 (defvar wgrep-mode-map nil)
 
-;;
-;; Internal variable
-;;
+;;;;
+;;;; Internal variable
+;;;;
 
 (defvar wgrep-readonly-state nil)
 (make-variable-buffer-local 'wgrep-readonly-state)
@@ -181,9 +181,9 @@ Key to enable `wgrep-mode'."
 ;; GNU Emacs have this variable at least version 21 or later
 (defvar auto-coding-regexp-alist)
 
-;;
-;; Constant
-;;
+;;;;
+;;;; Constant
+;;;;
 
 ;; These regexp come from `grep-regexp-alist' at grep.el
 (eval-and-compile
@@ -207,15 +207,15 @@ Key to enable `wgrep-mode'."
      wgrep-colon-file-separator-header-regexp
      "\\)")))
 
-;;
-;; Error
-;;
+;;;;
+;;;; Error
+;;;;
 
 (define-error 'wgrep-error "wgrep error")
 
-;;
-;; Overridable functions / regexp
-;;
+;;;;
+;;;; Overridable functions / regexp
+;;;;
 
 (defvar wgrep-line-file-regexp wgrep-default-line-header-regexp
   "Regexp that match to line header of grep result.
@@ -240,9 +240,9 @@ non editable region.")
 ;;; Basic utilities
 ;;;
 
-;;
-;; misc
-;;
+;;;;
+;;;; misc
+;;;;
 
 ;;Hack function
 (defun wgrep-string-replace-bom (string cs)
@@ -273,9 +273,9 @@ non editable region.")
     (or (null proc)
         (eq (process-status proc) 'exit))))
 
-;;
-;; error
-;;
+;;;;
+;;;; error
+;;;;
 
 (defun wgrep-check-file (file)
   (unless (file-exists-p file)
@@ -283,9 +283,9 @@ non editable region.")
   (unless (file-writable-p file)
     (signal 'wgrep-error (list "File is not writable."))))
 
-;;
-;; overlay
-;;
+;;;;
+;;;; overlay
+;;;;
 
 (defun wgrep-cleanup-overlays (beg end)
   (dolist (ov (overlays-in beg end))


### PR DESCRIPTION
`outline-minor-mode' needs to be able to tell the difference between
regular comments and section headings, so headings begin with three
semicolons.  For the same reason sub-section headings have to begin
with more, not less, semicolons.