### PR TITLE
"Software" has no plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ M-x wgrep-save-all-buffers
 - Can handle newline insertion in *grep* buffer.
 - Delete whole line include newline.
 
-### Similar softwares:
+### Similar software:
 
 [GNU sed](https://www.gnu.org/software/sed/)
 [helm-ag](https://github.com/syohex/emacs-helm-ag) has a similar feature.

--- a/wgrep.el
+++ b/wgrep.el
@@ -80,7 +80,7 @@
 ;; - Can handle newline insertion in *grep* buffer.
 ;; - Delete whole line include newline.
 
-;; ### Similar softwares:
+;; ### Similar software:
 
 ;; [GNU sed](https://www.gnu.org/software/sed/)
 ;; [helm-ag](https://github.com/syohex/emacs-helm-ag) has a similar feature.


### PR DESCRIPTION
Some words don't have a plural form in the English language.
"Software" is one of them.