### PR TITLE
Turn on lexical-binding

### DIFF
--- a/wgrep-ack.el
+++ b/wgrep-ack.el
@@ -1,4 +1,4 @@
-;;; wgrep-ack.el --- Writable ack-and-a-half buffer and apply the changes to files
+;;; wgrep-ack.el --- Writable ack-and-a-half buffer and apply the changes to files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2020 Masahiro Hayashi
 

--- a/wgrep-ag.el
+++ b/wgrep-ag.el
@@ -1,4 +1,4 @@
-;;; wgrep-ag.el --- Writable ag buffer and apply the changes to files
+;;; wgrep-ag.el --- Writable ag buffer and apply the changes to files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2020 Masahiro Hayashi
 

--- a/wgrep-helm.el
+++ b/wgrep-helm.el
@@ -1,4 +1,4 @@
-;;; wgrep-helm.el --- Writable helm-grep-mode buffer and apply the changes to files
+;;; wgrep-helm.el --- Writable helm-grep-mode buffer and apply the changes to files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2020 Masahiro Hayashi
 

--- a/wgrep-pt.el
+++ b/wgrep-pt.el
@@ -1,4 +1,4 @@
-;;; wgrep-pt.el --- Writable pt buffer and apply the changes to files
+;;; wgrep-pt.el --- Writable pt buffer and apply the changes to files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2020 Masahiro Hayashi
 

--- a/wgrep.el
+++ b/wgrep.el
@@ -1,4 +1,4 @@
-;;; wgrep.el --- Writable grep buffer and apply the changes to files
+;;; wgrep.el --- Writable grep buffer and apply the changes to files -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2020 Masahiro Hayashi
 
@@ -488,10 +488,6 @@ non editable region.")
                (line (string-to-number (match-string 3)))
                (start (match-beginning 0))
                (end (match-end 0))
-               (fstart (match-beginning 1))
-               (fend (match-end 1))
-               (lstart (match-beginning 3))
-               (lend (match-end 3))
                (fprop (wgrep-construct-filename-property fn))
                (flen (length fn)))
           ;; check relative path grep result
@@ -651,7 +647,7 @@ non editable region.")
         (overlay-put ov 'wgrep-edit-text value))))
     ov))
 
-(defun wgrep-after-change-function (beg end leng-before)
+(defun wgrep-after-change-function (beg end _leng-before)
   (cond
    (wgrep-inhibit-modification-hook nil)
    ((= (point-min) (point-max))
@@ -729,15 +725,14 @@ non editable region.")
   (dolist (prop '(modification-hooks insert-in-front-hooks insert-behind-hooks))
     (overlay-put
      ov prop
-     `((lambda (ov after-p &rest ignore)
-         (when after-p
-           (delete-overlay ov)))))))
+     `(,(lambda (ov after-p &rest _ignore)
+          (when after-p
+            (delete-overlay ov)))))))
 
 (defun wgrep-replace-to-new-line (new-text)
   ;; delete grep extracted region (restricted to a line)
   (delete-region (line-beginning-position) (line-end-position))
-  (let ((beg (point))
-        end)
+  (let ((beg (point)))
     (insert new-text)
     (let* ((end (point))
            ;; highlight the changed line
@@ -767,7 +762,6 @@ non editable region.")
                (start (next-single-property-change
                        (point) 'wgrep-line-filename nil (line-end-position)))
                (file (expand-file-name name default-directory))
-               (file-error nil)
                (old (overlay-get edit-field 'wgrep-old-text))
                (new (overlay-get edit-field 'wgrep-edit-text))
                result)
@@ -859,7 +853,6 @@ non editable region.")
   ;; Apply EDITOR to file/buffer. See `wgrep-compute-transaction'.
   ;; Return succeeded count and first result overlay in *grep* buffer.
   (let* ((file (car editor))
-         (edits (cdr editor))
          (open-buffer (get-file-buffer file))
          (buffer
           (cond


### PR DESCRIPTION
This helps the gccemacs native compiler and improves
compiler warnings (unused variables).