### PR TITLE
Use line-beginning-position instead of point-at-bol

### DIFF
--- a/wgrep-ag.el
+++ b/wgrep-ag.el
@@ -67,14 +67,14 @@ when you manage to call ag with --nogroup.")
     (goto-char (point-min))
     ;; Look for the first useful result line.
     (if (re-search-forward (concat wgrep-ag-grouped-result-file-regexp
-				   "\\|"
-				   wgrep-ag-ungrouped-result-regexp))
-	(add-text-properties (point-min) (line-beginning-position)
-			     '(read-only t wgrep-header t))
+                                   "\\|"
+                                   wgrep-ag-ungrouped-result-regexp))
+        (add-text-properties (point-min) (line-beginning-position)
+                             '(read-only t wgrep-header t))
       ;; No results in this buffer, let's mark the whole thing as
       ;; header.
       (add-text-properties (point-min) (point-max)
-			   '(read-only t wgrep-header t)))
+                           '(read-only t wgrep-header t)))
 
     ;; OK, header dealt with. Now let's try find the footer.
     (goto-char (point-max))
@@ -87,7 +87,7 @@ when you manage to call ag with --nogroup.")
     ;; footer.
     (when (zerop (forward-line 1))
       (add-text-properties (point) (point-max)
-			   '(read-only t wgrep-footer t)))))
+                           '(read-only t wgrep-footer t)))))
 
 (defun wgrep-ag-parse-command-results ()
   ;; Note that this function is called with the buffer narrowed to

--- a/wgrep-subtest.el
+++ b/wgrep-subtest.el
@@ -28,4 +28,3 @@
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
        (should (equal "FOO2\nBAZ\n" (wgrep-test--get-contents file)))))))
-

--- a/wgrep.el
+++ b/wgrep.el
@@ -1009,7 +1009,7 @@ These changes are not immediately saved to disk unless
      ((> all-length wgrep-too-many-file-length)
       (when (y-or-n-p (eval-when-compile
                         (concat
-                         "Edited files are too many." 
+                         "Edited files are too many."
                          " Apply the changes to disk with non-confirmation?")))
         (setq wgrep-auto-apply-disk t))))
     (while tran


### PR DESCRIPTION
Likewise use line-end-position instead of point-at-eol.

The point-at-{bol,eol} functions are obsolete since
Emacs 29 / b7e867b841f47dcff3aeaef9b5608a237386ce70.