### PR TITLE
Fix test extra loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ EL += wgrep-ag.el
 EL += wgrep-helm.el
 EL += wgrep-pt.el
 EL += wgrep-deadgrep.el
+EL += wgrep-test-helper.el
 
 TEST_EL := wgrep-test.el
 

--- a/wgrep-subtest.el
+++ b/wgrep-subtest.el
@@ -1,23 +1,13 @@
 (require 'ert)
-(require 'wgrep-test)
+(require 'wgrep-test-helper)
 (require 'ag)
-
-(defun wgrep-test--ag (string file)
-  (let ((buf (ag/search string default-directory :file-regex (regexp-quote file) :regexp t)))
-    (wgrep-test--wait buf)))
-
-(defun wgrep-test--deadgrep (string)
-  (let ((deadgrep-project-root-function (lambda () default-directory))
-        (deadgrep--search-type 'regexp))
-    (deadgrep string))
-  (wgrep-test--wait (current-buffer)))
 
 (ert-deftest wgrep-ag-normal ()
   :tags '(wgrep-subtest)
   (wgrep-test/default
    (wgrep-test-fixture "HOGE\nFOO\nBAZ\n"
      (lambda (file)
-       (wgrep-test--ag "FOO|HOGE" file)
+       (wgrep-test-helper--ag "FOO|HOGE" file)
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        (wgrep-goto-first-found)
@@ -33,14 +23,14 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "FOO2\nBAZ\n" (wgrep-test--get-contents file)))))))
+       (should (equal "FOO2\nBAZ\n" (wgrep-test-helper--get-contents file)))))))
 
 (ert-deftest wgrep-deadgrep-normal ()
   :tags '(wgrep-subtest)
   (wgrep-test/default
    (wgrep-test-fixture "HOGE\nFOO\nBAZ\n"
      (lambda (file)
-       (wgrep-test--deadgrep "FOO|HOGE")
+       (wgrep-test-helper--deadgrep "FOO|HOGE")
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        (wgrep-goto-first-found)
@@ -56,4 +46,4 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "FOO2\nBAZ\n" (wgrep-test--get-contents file)))))))
+       (should (equal "FOO2\nBAZ\n" (wgrep-test-helper--get-contents file)))))))

--- a/wgrep-test-helper.el
+++ b/wgrep-test-helper.el
@@ -1,0 +1,59 @@
+;;; wgrep-test-helper.el --- A wgrep test helper -*- lexical-binding: t -*-
+
+;; URL: http://github.com/mhayashi1120/Emacs-wgrep/raw/master/wgrep-test-helper.el
+;; Package-Requires: ((emacs "25.1"))
+
+;;; Commentary:
+
+;; A set of helper functions for ERT tests.
+
+(require 'wgrep)
+
+(defun wgre-test-helper--wait (buf)
+  (let ((proc (get-buffer-process buf)))
+    (while (eq (process-status proc) 'run)
+      (sit-for 0.1))
+    (sleep-for 0.2)
+    (switch-to-buffer buf)))
+
+(defun wgre-test-helper--grep (command)
+  (let ((buf (grep command)))
+    (wgre-test-helper--wait buf)))
+
+(defun wgre-test-helper--get-contents (file &optional cs)
+  (let ((coding-system-for-read cs))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (buffer-string))))
+
+(defun wgre-test-helper--prepare-file (file contents &optional cs)
+  ;; cleanup for convenience
+  (let ((buf (get-file-buffer file)))
+    (when (buffer-live-p buf)
+      (kill-buffer buf)))
+  (let ((coding-system-for-write cs))
+    (write-region contents nil file)))
+
+(defun wgre-test-helper--cleanup-file (file)
+  (when (file-exists-p file)
+    (delete-file file))
+  (when (file-exists-p (concat file "~"))
+    (delete-file (concat file "~"))))
+
+(defmacro wgre-test-helper--default (&rest body)
+  `(let ((wgrep-change-readonly-file nil)
+         (wgrep-auto-save-buffer nil))
+     (progn ,@body)))
+
+(defun wgrep-test-helper--ag (string file)
+  (let ((buf (ag/search string default-directory :file-regex (regexp-quote file) :regexp t)))
+    (wgrep-test-helper--wait buf)))
+
+(defun wgrep-test-helper--deadgrep (string)
+  (let ((deadgrep-project-root-function (lambda () default-directory))
+        (deadgrep--search-type 'regexp))
+    (deadgrep string))
+  (wgrep-test-helper--wait (current-buffer)))
+
+
+(provide 'wgre-test-helper)

--- a/wgrep-test.el
+++ b/wgrep-test.el
@@ -1,43 +1,7 @@
 (require 'ert)
 (require 'dash)
 (require 's)
-(require 'wgrep)
-
-(defun wgrep-test--wait (buf)
-  (let ((proc (get-buffer-process buf)))
-    (while (eq (process-status proc) 'run)
-      (sit-for 0.1))
-    (sleep-for 0.2)
-    (switch-to-buffer buf)))
-
-(defun wgrep-test--grep (command)
-  (let ((buf (grep command)))
-    (wgrep-test--wait buf)))
-
-(defun wgrep-test--get-contents (file &optional cs)
-  (let ((coding-system-for-read cs))
-    (with-temp-buffer
-      (insert-file-contents file)
-      (buffer-string))))
-
-(defun wgrep-test--prepare-file (file contents &optional cs)
-  ;; cleanup for convenience
-  (let ((buf (get-file-buffer file)))
-    (when (buffer-live-p buf)
-      (kill-buffer buf)))
-  (let ((coding-system-for-write cs))
-    (write-region contents nil file)))
-
-(defun wgrep-test--cleanup-file (file)
-  (when (file-exists-p file)
-    (delete-file file))
-  (when (file-exists-p (concat file "~"))
-    (delete-file (concat file "~"))))
-
-(defmacro wgrep-test/default (&rest body)
-  `(let ((wgrep-change-readonly-file nil)
-         (wgrep-auto-save-buffer nil))
-     (progn ,@body)))
+(require 'wgrep-test-helper)
 
 (defun wgrep-test-fixture (data body-fn)
   (let ((test-directory (expand-file-name "test-work" default-directory)))
@@ -47,14 +11,14 @@
       (let ((file (concat (make-temp-name "test-data") ".txt")))
         (pcase data
           ((pred stringp)
-           (wgrep-test--prepare-file file data))
+           (wgrep-test-helper--prepare-file file data))
           (`(,(and (pred stringp) data) ,(and (pred coding-system-p) cs))
-           (wgrep-test--prepare-file file data cs))
+           (wgrep-test-helper--prepare-file file data cs))
           (_
            (error "DATA should be STRING or (STRING CODING-SYSTEM)")))
         (unwind-protect
             (funcall body-fn file)
-          (wgrep-test--cleanup-file file))))))
+          (wgrep-test-helper--cleanup-file file))))))
 
 (put 'wgrep-test-fixture 'lisp-indent-function 1)
 
@@ -63,7 +27,7 @@
   (wgrep-test/default
    (wgrep-test-fixture "HOGE\nFOO\nBAZ\n"
      (lambda (file)
-       (wgrep-test--grep (concat "grep -nH -e FOO -C 1 " file))
+       (wgrep-test-helper--grep (concat "grep -nH -e FOO -C 1 " file))
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        ;; header is readonly
@@ -84,14 +48,14 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "FOO2\nBAZ\n" (wgrep-test--get-contents file)))))))
+       (should (equal "FOO2\nBAZ\n" (wgrep-test-helper--get-contents file)))))))
 
 (ert-deftest wgrep-normal-with-newline ()
   :tags '(wgrep)
   (wgrep-test/default
    (wgrep-test-fixture "HOGE\n"
      (lambda (file)
-       (wgrep-test--grep (concat "grep -nH -e HOGE " file))
+       (wgrep-test-helper--grep (concat "grep -nH -e HOGE " file))
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        ;; through the header
@@ -104,14 +68,14 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "FOO\nBAZ\n" (wgrep-test--get-contents file)))))))
+       (should (equal "FOO\nBAZ\n" (wgrep-test-helper--get-contents file)))))))
 
 (ert-deftest wgrep-bom-with-multibyte ()
   :tags '(wgrep)
   (wgrep-test/default
    (wgrep-test-fixture '("あ\nい\nう\n" utf-8-with-signature)
      (lambda (file)
-       (wgrep-test--grep (concat "grep -nH -e 'あ' -A 2 " file))
+       (wgrep-test-helper--grep (concat "grep -nH -e 'あ' -A 2 " file))
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        ;; BOM check is valid.
@@ -126,7 +90,7 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "へのへのも\nへじ\nう\n" (wgrep-test--get-contents file)))
+       (should (equal "へのへのも\nへじ\nう\n" (wgrep-test-helper--get-contents file)))
        ))))
 
 (ert-deftest wgrep-bom-with-unibyte ()
@@ -134,7 +98,7 @@
   (wgrep-test/default
    (wgrep-test-fixture '("a\nb\n" utf-8-with-signature)
      (lambda (file)
-       (wgrep-test--grep (concat "grep -nH -e 'a' -A 2 " file))
+       (wgrep-test-helper--grep (concat "grep -nH -e 'a' -A 2 " file))
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        ;; BOM check is valid.
@@ -145,7 +109,7 @@
        ;; save to file
        (wgrep-save-all-buffers)
        ;; compare file contents is valid
-       (should (equal "ABCD\nb\n" (wgrep-test--get-contents file)))))))
+       (should (equal "ABCD\nb\n" (wgrep-test-helper--get-contents file)))))))
 
 (ert-deftest wgrep-with-modify ()
   :tags '(wgrep)
@@ -162,7 +126,7 @@
                 (replace-match "hoge"))
            (and (re-search-forward "^b" nil t)
                 (replace-match "foo")))
-         (wgrep-test--grep (concat "grep -nH -e 'a' -A 2 " file))
+         (wgrep-test-helper--grep (concat "grep -nH -e 'a' -A 2 " file))
          (wgrep-change-to-wgrep-mode)
          (goto-char (point-min))
          ;; delete "a" line (failed when saving)
@@ -179,7 +143,7 @@
          ;; save to file
          (wgrep-save-all-buffers)
          ;; compare file contents is valid. (keep preceding file buffer's contents)
-         (should (equal "hoge\nfoo\nC\n" (wgrep-test--get-contents file))))))))
+         (should (equal "hoge\nfoo\nC\n" (wgrep-test-helper--get-contents file))))))))
 
 (ert-deftest wgrep-with-readonly-file ()
   :tags '(wgrep)
@@ -188,7 +152,7 @@
      (lambda (file)
        ;; make readonly
        (set-file-modes file ?\400)
-       (wgrep-test--grep (concat "grep -nH -e 'a' " file))
+       (wgrep-test-helper--grep (concat "grep -nH -e 'a' " file))
        (wgrep-change-to-wgrep-mode)
        (goto-char (point-min))
        (should (re-search-forward (concat (regexp-quote file) ":[0-9]+:.*\\(a\\)$") nil t))


### PR DESCRIPTION
* Since Emacs 29, test names cannot be duplicated.  This also applies to ert-deftest that are loaded through `requires', which means requiring another test unit may cause the same test being loaded more than once and causing the same error.

* This patch puts common test utility in a separate module so as to avoid including another test unit as a whole.

* See also Debian bug: https://bugs.debian.org/1057559