### PR TITLE
Ensure locale is UTF-8 compatible

### DIFF
--- a/wgrep-test-helper.el
+++ b/wgrep-test-helper.el
@@ -64,6 +64,7 @@
           (_
            (error "DATA should be STRING or (STRING CODING-SYSTEM)")))
         (unwind-protect
+            (setenv "LC_ALL" "C.UTF-8")
             (funcall body-fn file)
           (wgrep-test-helper--cleanup-file file))))))
 


### PR DESCRIPTION
* Some of the tests, especially wgrep-bom-with-{multibyte,unibyte} require a UTF-8 locale to work correctly.
* This patch ensures LC_ALL is set to C.UTF-8 in the fixture so that it is applied before running all tests.  (C.UTF-8 should be available for all Glibc based system.)
* Thanks for Jeremy Sowden for debugging and suggesting the fix: https://lists.debian.org/debian-emacsen/2024/01/msg00013.html